### PR TITLE
Fix compatibility con Vercel - revertir cambios de await cookies()

### DIFF
--- a/app/api/ai/config/route.ts
+++ b/app/api/ai/config/route.ts
@@ -7,8 +7,7 @@ import { NextResponse } from "next/server";
  */
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
+    const supabase = createRouteHandlerClient({ cookies });
 
     const { data: config, error } = await supabase
       .from("api_config")
@@ -42,8 +41,7 @@ export async function GET() {
  */
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
+    const supabase = createRouteHandlerClient({ cookies });
     const body = await request.json();
 
     const { api_key } = body;

--- a/app/api/ai/list-all-models/route.ts
+++ b/app/api/ai/list-all-models/route.ts
@@ -8,8 +8,7 @@ import { NextResponse } from "next/server";
  */
 export async function GET() {
   try {
-    const cookieStore = await cookies();
-    const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
+    const supabase = createRouteHandlerClient({ cookies });
 
     // Obtener API key configurada
     const { data: apiConfig } = await supabase

--- a/app/api/ai/models/route.ts
+++ b/app/api/ai/models/route.ts
@@ -9,8 +9,7 @@ import { NextResponse } from "next/server";
  */
 export async function GET(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
+    const supabase = createRouteHandlerClient({ cookies });
     const { searchParams } = new URL(request.url);
     const activeOnly = searchParams.get("active_only") === "true";
 
@@ -40,8 +39,7 @@ export async function GET(request: Request) {
  */
 export async function POST(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
+    const supabase = createRouteHandlerClient({ cookies });
     const body = await request.json();
 
     const {
@@ -109,8 +107,7 @@ export async function POST(request: Request) {
  */
 export async function PATCH(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
+    const supabase = createRouteHandlerClient({ cookies });
     const body = await request.json();
     const { id, ...updates } = body;
 
@@ -156,8 +153,7 @@ export async function PATCH(request: Request) {
  */
 export async function DELETE(request: Request) {
   try {
-    const cookieStore = await cookies();
-    const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
+    const supabase = createRouteHandlerClient({ cookies });
     const { searchParams } = new URL(request.url);
     const id = searchParams.get("id");
 

--- a/app/api/ai/sync-models/route.ts
+++ b/app/api/ai/sync-models/route.ts
@@ -8,8 +8,7 @@ import { NextResponse } from "next/server";
  */
 export async function POST() {
   try {
-    const cookieStore = await cookies();
-    const supabase = createRouteHandlerClient({ cookies: () => cookieStore });
+    const supabase = createRouteHandlerClient({ cookies });
 
     // Obtener API key configurada
     const { data: apiConfig } = await supabase


### PR DESCRIPTION
- Revertir cambios de await cookies() en todos los endpoints API
- La sintaxis createRouteHandlerClient({ cookies }) funciona en ambos entornos
- Fix error de compilación en Vercel: Type ReadonlyRequestCookies missing Promise properties